### PR TITLE
Update to ngrok 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM        progrium/busybox
 MAINTAINER  Fletcher Nichol <fnichol@nichol.ca>
 
-RUN opkg-install curl
-RUN curl -Lk 'https://api.equinox.io/1/Applications/ap_pJSFC5wQYkAyI0FIVwKYs9h1hW/Updates/Asset/ngrok.zip?os=linux&arch=amd64&channel=stable' > ngrok.zip
-RUN unzip ngrok.zip -d /bin && rm -f ngrok.zip
-RUN echo 'inspect_addr: 0.0.0.0:4040' > /.ngrok
+ENV HOME /root
+
+ADD https://dl.ngrok.com/ngrok_2.0.19_linux_amd64.zip $HOME/ngrok.zip
+RUN unzip $HOME/ngrok.zip -d /bin && rm -f $HOME/ngrok.zip
+ADD ngrok.yml $HOME/ngrok.yml
 ADD ngrok_discover /bin/ngrok_discover
-RUN chmod +x /bin/ngrok_discover
 
 EXPOSE 4040
 

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,0 +1,3 @@
+web_addr: 0.0.0.0:4040
+update: false
+log: stdout

--- a/ngrok_discover
+++ b/ngrok_discover
@@ -12,7 +12,7 @@ fi
 
 case "$1" in
   -h|help)  ARGS=$1 ;;
-  *)        ARGS="-config /.ngrok -log stdout $* $FWD" ;;
+  *)        ARGS="--config $HOME/ngrok.yml $* $FWD" ;;
 esac
 
-exec /bin/ngrok $ARGS
+exec /bin/ngrok http $ARGS

--- a/ngrok_discover
+++ b/ngrok_discover
@@ -8,11 +8,19 @@ if [ -n "$HTTPS_PORT" ]; then
   FWD="`echo $HTTPS_PORT | sed 's|^tcp://||'`"
 elif [ -n "$HTTP_PORT" ]; then
   FWD="`echo $HTTP_PORT | sed 's|^tcp://||'`"
+elif [ -n "$1" ]; then
+  FWD="$1"
+else
+  echo "Must be run with a link aliased to http or https, an environmental variable (HTTP_PORT), or passed as a command."
+  echo "=> Example: docker run --link app:http fnichol/ngrok"
+  echo "=> Example: docker run -e HTTP_PORT 8080 fnichol/ngrok"
+  echo "=> Example: docker run fnichol/ngrok 80"
+  exit 1
 fi
 
 case "$1" in
   -h|help)  ARGS=$1 ;;
-  *)        ARGS="--config $HOME/ngrok.yml $* $FWD" ;;
+  *)        ARGS="--config $HOME/ngrok.yml $FWD" ;;
 esac
 
 exec /bin/ngrok http $ARGS


### PR DESCRIPTION
### What is the problem / feature ?

I was running into issues with using ngrok 1.7, so I updated to ngrok 2.0. As part of that, I was sometimes forgetting to properly set the tunnel parameters, which would end up creating tunnels to nowhere.
### How did it get fixed / implemented ?
- Dockerfile cleanup:
  - Update download to pull ngrok 2.0
  - Use `ADD` instead of curl for downloading files into container
  - Reduce number of steps
-  Add a ngrok.yml file for standard configuration
- `ngrok_discover` improvements:
  - Update to use ngrok 2.0 http forwarding
  - Leverage new ngrok.yml to reduce command line args
  - Script now has the execute bit set
  - Add a check for the tunnel settings
